### PR TITLE
Update LAB_0506_Configure_Infrastructure_Backup.md

### DIFF
--- a/Instructions/Labs/LAB_0506_Configure_Infrastructure_Backup.md
+++ b/Instructions/Labs/LAB_0506_Configure_Infrastructure_Backup.md
@@ -144,7 +144,7 @@ In this task, you will:
 1. On the **Backup controller settings** blade, in the **Encryption Settings** section, next to the **Certificate .cer file** text box, select the folder icon, in the **Open** dialog box, navigate to the **C:\\CertStore** folder, select the **AzSHIBPK.cer** file, and select **Open**.
 1. On the **Backup controller settings** blade, specify the following settings and click **OK**:
 
-    - Backup storage location: **\\AzSHOST-1.azurestack.local\Backup**
+    - Backup storage location: **\\\\AzSHOST-1.azurestack.local\Backup**
     - Username: **AzS-BackupOperator@azurestack.local**
     - Password: **Pa55w.rd**
     - Confirm password: **Pa55w.rd**


### PR DESCRIPTION
The `Backup storage location` setting at the Backup controller in the at task 4 only show one backslash instead two backslash.

# Module: 5: Manage Infrastructure  / 16 Plan and configure business continuity and disaster recovery for Azure Stack Hub
## Lab/Demo: Configure Azure Stack Hub infrastructure backup

Fixes # .

Changes proposed in this pull request:

- Task 4 markdown syntax.
-
-